### PR TITLE
Feat/import export project

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Toaster } from "sonner";
+import { AnalysisProvider } from "./context/AnalysisContext";
 import Header from "./components/Header";
 import Sidebar from "./components/Sidebar";
 import RouterLayout from "./routes/routes";
@@ -10,8 +11,9 @@ function App() {
         <Header />
         <div className="flex h-[calc(100vh-48px)] w-full flex-1">
           <Sidebar />
-
-          <RouterLayout />
+          <AnalysisProvider>
+            <RouterLayout />
+          </AnalysisProvider>
           <Toaster duration={3000} richColors className="select-none" />
         </div>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,14 +1,44 @@
 import { useTranslation } from "react-i18next";
 import DropdownBtn from "./dropdownBtn";
 import Logo from "./logo";
+import { toast } from "sonner";
+import { Button } from "./ui/button";
+import { Download } from "lucide-react";
 
 function Header() {
   const { t } = useTranslation("translation", { keyPrefix: "header.link" });
+  const handleExport = async () => {
+    try {
+      const ok = await window.electronFile.exportProject();
+      if (ok) {
+        toast.success(t("exportProject.success"));
+      } else {
+        toast.error(t("exportProject.error"));
+      }
+    } catch (e) {
+      toast.error(t("exportProject.error"));
+    }
+  };
+
   return (
     <div className="flex h-12 w-full items-center justify-between border-b-[1px] border-[var(--color-divider)] px-4 select-none lg:h-16 lg:px-10">
       <Logo />
-      <div className="flex items-center gap-4 lg:gap-4">
-        {/* as tags "p" vao virar rotas posteriormente */}
+      <div className="flex items-center gap-3 lg:gap-4">
+        <Button
+          onClick={handleExport}
+          variant="outline"
+          size="sm"
+          className="group font-poppins relative flex cursor-pointer items-center gap-1.5 overflow-hidden border-[var(--color-divider)]/70 text-[10px] font-semibold tracking-wide uppercase hover:border-[var(--color-divider)] hover:bg-[var(--color-divider)]/10"
+          aria-label={t("exportProject.button") as string}
+        >
+          <Download
+            size={14}
+            className="text-[var(--text-primaryGray)] transition-transform group-hover:scale-110"
+          />
+          <span className="relative top-[2px] z-10 text-[var(--text-primaryGray)] group-hover:text-[var(--text-primaryGray)]">
+            {t("exportProject.button")}
+          </span>
+        </Button>
         <DropdownBtn />
         <p className="font-poppins cursor-pointer text-xs font-semibold text-[var(--text-primaryGray)]">
           {t("help")}

--- a/frontend/src/components/section-content/BtnLoaderProject.tsx
+++ b/frontend/src/components/section-content/BtnLoaderProject.tsx
@@ -1,17 +1,51 @@
 import { useTranslation } from "react-i18next";
 import { Button } from "../ui/button";
+import { toast } from "sonner";
+import { Upload } from "lucide-react";
 
 function BtnLoaderProject() {
-  const { t } = useTranslation("translation", {
-    keyPrefix: "content.home.modal",
-  });
+  const { t } = useTranslation("translation");
+
+  const handleImport = async () => {
+    try {
+      const result = await window.electronFile.importProject();
+      if (!result || !result.success) {
+        if (result?.error === "CANCELED") return;
+        if (result?.error === "INVALID_JSON") {
+          toast.error(
+            t("header.link.importProject.invalid"),
+          );
+          return;
+        }
+        if (result?.error?.startsWith("MISSING_FIELD_")) {
+          toast.error(
+            t("header.link.importProject.invalid"),
+          );
+          return;
+        }
+        toast.error(
+          t("header.link.importProject.error"),
+        );
+        return;
+      }
+      toast.success(
+        t("header.link.importProject.success"),
+      );
+    } catch (e) {
+      toast.error(
+        t("header.link.importProject.error"),
+      );
+    }
+  };
+
   return (
     <Button
-      disabled
+      onClick={handleImport}
       variant="secondary"
-      className="text-textPrimary font-inter h-[30px] cursor-pointer rounded-full bg-[#F2F2F5] px-4 text-[10px] font-bold select-none"
+      className="text-textPrimary font-inter flex h-[30px] cursor-pointer items-center gap-1 rounded-full bg-[#F2F2F5] px-4 text-[10px] font-bold select-none"
     >
-      {t("loaderProject")}
+      <Upload size={12} />
+  {t("header.link.importProject.button")}
     </Button>
   );
 }

--- a/frontend/src/components/section-content/BtnModal.tsx
+++ b/frontend/src/components/section-content/BtnModal.tsx
@@ -28,12 +28,13 @@ function BtnModal() {
     setNameProject("");
   };
 
-  const handleNewProject = () => {
-    window.electronFile.newProject();
+  const handleNewProject = (name: string) => {
+    window.electronFile.newProject(name);
   };
 
   const handleSubmit = () => {
     if (nameProject.trim().length >= 2) {
+      handleNewProject(nameProject.trim());
       setOpen(false);
       toast.success(`${t("toastSuccess")}`);
       navigate("/processSample");
@@ -88,7 +89,6 @@ function BtnModal() {
               disabled={nameProject.trim().length < 2}
               onClick={() => {
                 handleSubmit();
-                handleNewProject();
               }}
             >
               {t("createButton")}

--- a/frontend/src/context/AnalysisContext.tsx
+++ b/frontend/src/context/AnalysisContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+type AnalysisResult = any;
+
+interface AnalysisContextType {
+  results: AnalysisResult | null;
+  setResults: (results: AnalysisResult | null) => void;
+}
+
+const AnalysisContext = createContext<AnalysisContextType | undefined>(
+  undefined,
+);
+
+export function AnalysisProvider({ children }: { children: ReactNode }) {
+  const [results, setResults] = useState<AnalysisResult | null>(null);
+
+  return (
+    <AnalysisContext.Provider value={{ results, setResults }}>
+      {children}
+    </AnalysisContext.Provider>
+  );
+}
+
+export function useAnalysisContext() {
+  const context = useContext(AnalysisContext);
+  if (context === undefined) {
+    throw new Error(
+      "useAnalysisContext must be used within an AnalysisProvider",
+    );
+  }
+  return context;
+}

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -1,7 +1,6 @@
 import {
   processFastq,
   processTimGalore,
-  setLastResult,
 } from "@/services/processSampleService";
 import type { FileData } from "@/types/index";
 import { useEffect, useRef, useState } from "react";
@@ -72,9 +71,10 @@ export function useAnalysis() {
 
       setProgress(100);
       setIsRunning(false);
-      setLastResult({ fastqResult, trimGaloreResult });
 
       toast.success(t("analysis.completeToast"));
+
+      return { fastqResult, trimGaloreResult };
     } catch (error) {
       clearInterval(intervalRef.current!);
       setIsRunning(false);
@@ -84,7 +84,6 @@ export function useAnalysis() {
         error instanceof Error
           ? error.message
           : t("errors.analysisFailed", { message: "Erro desconhecido" });
-      // If error is an Error, use interpolation; else show generic message
       if (error instanceof Error) {
         toast.error(t("errors.analysisFailed", { message: error.message }));
       } else {

--- a/frontend/src/hooks/useFileHandler.ts
+++ b/frontend/src/hooks/useFileHandler.ts
@@ -3,9 +3,10 @@ import { FileData } from "../types/index";
 
 export function useFileHandler() {
   const [files, setFiles] = useState<FileData>({
-    fastq: { name: null, content: null },
-    fasta: { name: null, content: null },
-    gff: { name: null, content: null },
+    projectName: "",
+  fastq: { name: null, content: null, path: null },
+  fasta: { name: null, content: null, path: null },
+  gff: { name: null, content: null, path: null },
     directory: { directory: null },
     transpFile: "",
     idFile: "",
@@ -68,7 +69,7 @@ export function useFileHandler() {
       setFiles((prev) => {
         const updated = {
           ...prev,
-          [field]: { name: fileName, content: fileContent },
+          [field]: { name: fileName, content: fileContent ?? null, path: filePath },
         };
         persistFiles(updated);
         return updated;
@@ -115,6 +116,17 @@ export function useFileHandler() {
     });
   };
 
+  const updateProjectName = (value: string) => {
+    setFiles((prev) => {
+      const updated = { ...prev, projectName: value };
+      persistFiles(updated);
+      return updated;
+    });
+    if (window.electronFile?.setProjectName) {
+      window.electronFile.setProjectName(value);
+    }
+  };
+
   return {
     files,
     handleOpenFastq,
@@ -125,5 +137,6 @@ export function useFileHandler() {
     setTranspFile: updateTranspFile,
     idFile,
     setIdFile: updateIdFile,
+    setProjectName: updateProjectName,
   };
 }

--- a/frontend/src/lib/fileManager.ts
+++ b/frontend/src/lib/fileManager.ts
@@ -9,6 +9,7 @@ const getFilesPath = (): string => {
 };
 
 const getDefaultFileData = (): FileData => ({
+  projectName: "",
   fastq: { name: null, content: null },
   fasta: { name: null, content: null },
   gff: { name: null, content: null },
@@ -75,10 +76,41 @@ export const setAdvancedParams = (advancedParams: AdvancedParams): boolean => {
   }
 };
 
-export const createNewProject = (): void => {
+export const createNewProject = (name: string): void => {
   try {
-    saveFiles(getDefaultFileData());
+    const data = getDefaultFileData();
+    data.projectName = name;
+    saveFiles(data);
   } catch (error) {
     console.error("Erro ao criar novo projeto:", error);
+  }
+};
+
+export const setProjectName = (name: string): boolean => {
+  try {
+    const files = loadFiles();
+    files.projectName = name;
+    saveFiles(files);
+    return true;
+  } catch (error) {
+    console.error("Erro ao salvar nome do projeto:", error);
+    return false;
+  }
+};
+
+export const exportProjectToPath = (destPath: string): boolean => {
+  try {
+    const files = loadFiles();
+    const projectName =
+      files.projectName && files.projectName.trim() !== "" && files.projectName;
+
+    const finalPath = destPath.endsWith(".json")
+      ? destPath
+      : path.join(destPath, `${projectName}.json`);
+    fs.writeFileSync(finalPath, JSON.stringify(files, null, 2));
+    return true;
+  } catch (error) {
+    console.error("Erro ao exportar projeto:", error);
+    return false;
   }
 };

--- a/frontend/src/lib/fileManager.ts
+++ b/frontend/src/lib/fileManager.ts
@@ -114,3 +114,59 @@ export const exportProjectToPath = (destPath: string): boolean => {
     return false;
   }
 };
+
+export interface ImportResult {
+  success: boolean;
+  error?: string;
+  data?: FileData;
+}
+
+export const importProjectFromPath = (sourcePath: string): ImportResult => {
+  try {
+    if (!fs.existsSync(sourcePath)) {
+      return { success: false, error: "FILE_NOT_FOUND" };
+    }
+    const raw = fs.readFileSync(sourcePath, "utf8");
+    const json = JSON.parse(raw);
+
+    const requiredTop = [
+      "fastq",
+      "fasta",
+      "gff",
+      "directory",
+      "advancedParams",
+    ];
+    for (const key of requiredTop) {
+      if (!(key in json)) {
+        return { success: false, error: `MISSING_FIELD_${key}` };
+      }
+    }
+
+    const merged: FileData = {
+      projectName: json.projectName || "",
+      fastq: json.fastq || { name: null, content: null },
+      fasta: json.fasta || { name: null, content: null },
+      gff: json.gff || { name: null, content: null },
+      directory: json.directory || { directory: null },
+      transpFile: json.transpFile || "",
+      idFile: json.idFile || "",
+      advancedParams: {
+        minimumReadLength: json.advancedParams?.minimumReadLength ?? 0,
+        maximumReadLength: json.advancedParams?.maximumReadLength ?? 0,
+        trimmingQuality: json.advancedParams?.trimmingQuality ?? 0,
+        minimumMapingQuality: json.advancedParams?.minimumMapingQuality ?? 0,
+        numberOfThreadsForAnalysis:
+          json.advancedParams?.numberOfThreadsForAnalysis ?? 0,
+        minConfidenceThreshold:
+          json.advancedParams?.minConfidenceThreshold ?? 0,
+        maxNonEssentialGenes: json.advancedParams?.maxNonEssentialGenes ?? 0,
+      },
+    };
+
+    saveFiles(merged);
+    return { success: true, data: merged };
+  } catch (error) {
+    console.error("Erro ao importar projeto:", error);
+    return { success: false, error: "INVALID_JSON" };
+  }
+};

--- a/frontend/src/lib/ipcHandlers.ts
+++ b/frontend/src/lib/ipcHandlers.ts
@@ -11,7 +11,10 @@ import {
   loadFiles,
   saveFiles,
   setAdvancedParams,
+  setProjectName,
+  exportProjectToPath,
 } from "./fileManager";
+import { dialog } from "electron";
 import { getLanguage, setLanguage } from "./languageSettingsManager";
 
 const registerFileHandlers = (): void => {
@@ -24,8 +27,26 @@ const registerFileHandlers = (): void => {
     return true;
   });
 
-  ipcMain.handle("new-project", () => {
-    createNewProject();
+  ipcMain.handle("new-project", (_event, name: string) => {
+    createNewProject(name);
+  });
+
+  ipcMain.handle("set-project-name", (_event, name: string) => {
+    return setProjectName(name);
+  });
+
+  ipcMain.handle("export-project", async () => {
+    const { canceled, filePath } = await dialog.showSaveDialog({
+      defaultPath: `${loadFiles().projectName || "project"}.json`,
+      filters: [
+        {
+          name: "JSON",
+          extensions: ["json"],
+        },
+      ],
+    });
+    if (canceled || !filePath) return false;
+    return exportProjectToPath(filePath);
   });
 
   ipcMain.handle("get-advanced-params", () => {

--- a/frontend/src/lib/ipcHandlers.ts
+++ b/frontend/src/lib/ipcHandlers.ts
@@ -13,6 +13,7 @@ import {
   setAdvancedParams,
   setProjectName,
   exportProjectToPath,
+  importProjectFromPath,
 } from "./fileManager";
 import { dialog } from "electron";
 import { getLanguage, setLanguage } from "./languageSettingsManager";
@@ -47,6 +48,23 @@ const registerFileHandlers = (): void => {
     });
     if (canceled || !filePath) return false;
     return exportProjectToPath(filePath);
+  });
+
+  ipcMain.handle("import-project", async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ["openFile"],
+      filters: [
+        {
+          name: "JSON",
+          extensions: ["json"],
+        },
+      ],
+    });
+    if (canceled || !filePaths || filePaths.length === 0) {
+      return { success: false, error: "CANCELED" };
+    }
+    const result = importProjectFromPath(filePaths[0]);
+    return result;
   });
 
   ipcMain.handle("get-advanced-params", () => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -7,6 +7,13 @@
         "button": "Export project",
         "success": "Project exported successfully!",
         "error": "Failed to export project"
+      },
+      "importProject": {
+        "button": "Load Project",
+        "success": "Project imported successfully!",
+        "error": "Failed to import project",
+        "invalid": "Invalid project file",
+        "dialogTitle": "Load project"
       }
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2,7 +2,12 @@
   "header": {
     "link": {
       "help": "Help",
-      "about": "About"
+      "about": "About",
+      "exportProject": {
+        "button": "Export project",
+        "success": "Project exported successfully!",
+        "error": "Failed to export project"
+      }
     }
   },
   "content": {

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -2,7 +2,12 @@
   "header": {
     "link": {
       "help": "Ajuda",
-      "about": "Sobre"
+      "about": "Sobre",
+      "exportProject": {
+        "button": "Exportar projeto",
+        "success": "Projeto exportado com sucesso!",
+        "error": "Falha ao exportar o projeto"
+      }
     }
   },
   "content": {

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -7,6 +7,13 @@
         "button": "Exportar projeto",
         "success": "Projeto exportado com sucesso!",
         "error": "Falha ao exportar o projeto"
+      },
+      "importProject": {
+        "button": "Carregar Projeto",
+        "success": "Projeto importado com sucesso!",
+        "error": "Falha ao importar o projeto",
+        "invalid": "Arquivo de projeto inválido",
+        "dialogTitle": "Carregar projeto"
       }
     }
   },

--- a/frontend/src/pages/InteractiveAnalysisScreen.tsx
+++ b/frontend/src/pages/InteractiveAnalysisScreen.tsx
@@ -1,20 +1,9 @@
-import {
-  getLastResult,
-  subscribeToResults,
-} from "@/services/processSampleService";
-import { useEffect, useState } from "react";
+import { useAnalysisContext } from "@/context/AnalysisContext";
 import { useTranslation } from "react-i18next";
 
 function InteractiveAnalysisScreen() {
   const { t } = useTranslation("translation");
-  const [results, setResults] = useState<any | null>(() => getLastResult());
-
-  useEffect(() => {
-    const unsubscribe = subscribeToResults((data) => {
-      setResults(data);
-    });
-    return unsubscribe;
-  }, []);
+  const { results } = useAnalysisContext();
 
   const displayed = results ?? null;
 

--- a/frontend/src/pages/ProcessSampleScreen.tsx
+++ b/frontend/src/pages/ProcessSampleScreen.tsx
@@ -11,6 +11,7 @@ import { useAnalysis } from "@/hooks/useAnalysis";
 import { useFileHandler } from "@/hooks/useFileHandler";
 import { useInputAdvanced } from "@/hooks/useInputAdvanced";
 import { useTranslation } from "react-i18next";
+import { useAnalysisContext } from "@/context/AnalysisContext";
 
 function ProcessSampleScreen() {
   const { t } = useTranslation("translation", {
@@ -23,7 +24,8 @@ function ProcessSampleScreen() {
     startAnalysis,
     cancelAnalysis,
   } = useAnalysis();
-  const { values, onChange } = useInputAdvanced();
+  const { onChange, values } = useInputAdvanced();
+  const { setResults } = useAnalysisContext();
 
   const {
     files,
@@ -37,8 +39,11 @@ function ProcessSampleScreen() {
     setIdFile,
   } = useFileHandler();
 
-  const handleStartAnalysis = () => {
-    startAnalysis(files, transpFile);
+  const handleStartAnalysis = async () => {
+    const result = await startAnalysis(files, transpFile);
+    if (result) {
+      setResults(result);
+    }
   };
 
   return (

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld("electronFile", {
   setProjectName: (name: string) =>
     ipcRenderer.invoke("set-project-name", name),
   exportProject: () => ipcRenderer.invoke("export-project"),
+  importProject: () => ipcRenderer.invoke("import-project"),
   getAdvancedParams: () => ipcRenderer.invoke("get-advanced-params"),
   setAdvancedParams: (advancedParams: any) =>
     ipcRenderer.invoke("set-advanced-params", advancedParams),

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -16,7 +16,10 @@ contextBridge.exposeInMainWorld("electronFile", {
   openFileDialogDirectory: () => ipcRenderer.invoke("openFileDialogDirectory"),
   getFiles: () => ipcRenderer.invoke("get-files"),
   setFiles: (files: any) => ipcRenderer.invoke("set-files", files),
-  newProject: () => ipcRenderer.invoke("new-project"),
+  newProject: (name: string) => ipcRenderer.invoke("new-project", name),
+  setProjectName: (name: string) =>
+    ipcRenderer.invoke("set-project-name", name),
+  exportProject: () => ipcRenderer.invoke("export-project"),
   getAdvancedParams: () => ipcRenderer.invoke("get-advanced-params"),
   setAdvancedParams: (advancedParams: any) =>
     ipcRenderer.invoke("set-advanced-params", advancedParams),

--- a/frontend/src/services/processSampleService.ts
+++ b/frontend/src/services/processSampleService.ts
@@ -4,30 +4,6 @@ export type ProcessResult = any;
 
 const BASE_URL = "http://127.0.0.1:5000";
 
-let subscribers: Array<(data: ProcessResult) => void> = [];
-let lastResult: ProcessResult | null = null;
-
-export function subscribeToResults(cb: (data: ProcessResult) => void) {
-  subscribers.push(cb);
-  if (lastResult !== null) {
-    try {
-      cb(lastResult);
-    } catch (e) {}
-  }
-  return () => {
-    subscribers = subscribers.filter((s) => s !== cb);
-  };
-}
-
-export function getLastResult() {
-  return lastResult;
-}
-
-export function setLastResult(result: ProcessResult) {
-  lastResult = result;
-  subscribers.forEach((cb) => cb(result));
-}
-
 export async function processFastq(
   files: FileData,
   adapter: string,

--- a/frontend/src/services/processSampleService.ts
+++ b/frontend/src/services/processSampleService.ts
@@ -41,7 +41,10 @@ export async function processFastq(
   const blob = new Blob([files.fastq.content], { type: "text/plain" });
   formData.append("file", blob, files.fastq.name);
   formData.append("adapter", adapter);
-  formData.append("output_dir", outputDir);
+  if (outputDir) {
+    formData.append("output_dir", outputDir);
+  }
+  console.log("Output dir:", outputDir);
 
   const response = await fetch(`${BASE_URL}/process-fastq`, {
     method: "POST",
@@ -66,7 +69,9 @@ export async function processTimGalore(files: FileData, outputDir?: string) {
   const formData = new FormData();
   const blob = new Blob([files.fastq.content], { type: "text/plain" });
   formData.append("file", blob, files.fastq.name);
-  formData.append("output_dir", outputDir);
+  if (outputDir) {
+    formData.append("output_dir", outputDir);
+  }
 
   const response = await fetch(`${BASE_URL}/process-trimgalore`, {
     method: "POST",

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -14,7 +14,9 @@ export interface IElectronFileAPI {
   openFileDialogDirectory: FileDialogResultFunction;
   getFiles: () => Promise<FileData>;
   setFiles: (files: FileData) => Promise<boolean>;
-  newProject: () => Promise<void>;
+  newProject: (name: string) => Promise<void>;
+  setProjectName: (name: string) => Promise<boolean>;
+  exportProject: () => Promise<boolean>;
   getAdvancedParams: () => Promise<AdvancedParams>;
   setAdvancedParams: (advancedParams: AdvancedParams) => Promise<boolean>;
 }

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -17,6 +17,11 @@ export interface IElectronFileAPI {
   newProject: (name: string) => Promise<void>;
   setProjectName: (name: string) => Promise<boolean>;
   exportProject: () => Promise<boolean>;
+  importProject: () => Promise<{
+    success: boolean;
+    error?: string;
+    data?: FileData;
+  }>;
   getAdvancedParams: () => Promise<AdvancedParams>;
   setAdvancedParams: (advancedParams: AdvancedParams) => Promise<boolean>;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
-// Types for file management
 export interface FileData {
+  projectName: string;
   fastq: { name: string | null; content: string | null };
   fasta: { name: string | null; content: string | null };
   gff: { name: string | null; content: string | null };


### PR DESCRIPTION
# Descrição

Adicionar importação de projeto (JSON) para complementar export ja existente

## Principais Alterações

* fileManager.ts: importProjectFromPath (validação + persistência)
* ipcHandlers.ts: handler import-project
* preload.ts: exposto importProject
* electron.d.ts: tipagem do retorno { success; error?; data? }
* Traduções (pt/en): header.link.importProject.\*
* Header.tsx: mantém só export, vai ser temporario ate criar as novas telas 

## Erros Tratados

* CANCELED
* FILE\_NOT\_FOUND
* INVALID\_JSON
* MISSING\_FIELD\_\*

## Como Testar

* Exporte um projeto
* Importe o JSON exportado
* Teste arquivo inválido (remova um campo) → toast de inválido
* Cancelar diálogo → sem toast

